### PR TITLE
Socket 연결시 토큰 확인 로직 추가

### DIFF
--- a/backend/remote_game/game/consumers.py
+++ b/backend/remote_game/game/consumers.py
@@ -27,9 +27,6 @@ class GameConsumer(AsyncWebsocketConsumer):
             # match_name과 id 추출
             match_name = query_params.get('match_name', [None])[0]
             user_id = self.scope['session'].get('api_id')
-            session = self.scope['session']
-            session['previous_url'] = '/pingpong/remote' # 정확한 previous_url 설정 필요
-            await database_sync_to_async(session.save)()
             cookies = self.scope.get('cookies', {})
             access_token = cookies.get('access_token')
             if not access_token:
@@ -65,8 +62,7 @@ class GameConsumer(AsyncWebsocketConsumer):
         except (TokenError, InvalidToken) as e:
             logger.error(f'{e} exception in game consumer connect')
             await self.send(text_data=json.dumps({
-                'type': 'redirect',
-                'url': 'api/login/refresh',
+                'type': 'refresh',
             }))
             await self.close()
         except Exceptions.RemoteGameException as e:

--- a/backend/remote_game/waiting_queue/WaitingQueue.py
+++ b/backend/remote_game/waiting_queue/WaitingQueue.py
@@ -43,11 +43,11 @@ class WaitingQueue:
                         channel_name,
                         {
                             "type": "match_found",
-                            # 'data': {
-                            #     'status':'success',
-                            #     'message':f'{match_name}'
-                            # },
-                            "match_name": f'{match_name}',
+                            'data': {
+                                'type':'match_name',
+                                'match_name':f'{match_name}'
+                            },
+                            # "match_name": f'{match_name}',
                         }
                     )
             await asyncio.sleep(1)

--- a/backend/remote_game/waiting_queue/consumers.py
+++ b/backend/remote_game/waiting_queue/consumers.py
@@ -22,9 +22,6 @@ class WaitingQueueConsumer(AsyncWebsocketConsumer):
             query_params = urllib.parse.parse_qs(query_string)
             self.que_type = query_params.get('type', [None])[0]
             self.user_id = self.scope['session'].get('api_id')
-            session = self.scope['session']
-            session['previous_url'] = '/pingpong/remote' # 정확한 previous_url 설정 필요
-            await database_sync_to_async(session.save)()
             cookies = self.scope.get('cookies', {})
             access_token = cookies.get('access_token')
             await self.accept()
@@ -47,8 +44,7 @@ class WaitingQueueConsumer(AsyncWebsocketConsumer):
         except (TokenError, InvalidToken) as e:
             logger.error(f'{e} exception in game consumer connect')
             await self.send(text_data=json.dumps({
-                'type': 'redirect',
-                'url': 'api/login/refresh',
+                'type': 'refresh'
             }))
             await self.close()
         except Exception as e:


### PR DESCRIPTION
## 소켓 연결을 진행할 때, 토큰을 확인하게 됩니다.
1. 토큰이 유효하지 않은 경우에는, ``` 'type':'refresh'``` 를 프론트에 보낸 후, 연결을 종료합니다.
2. ```type``` 을 구분하기 위해서, 이전에는 plain text로 전달하던 match_name을 ```'type':'match_name', 'match_name':매치 이름``` 으로 보내주게 됩니다.